### PR TITLE
README.md: make project links relative #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ These are some of the sub projects (come with code, learning outcomes, exercises
 ### Project: AddressBook 
 A series of Java projects with increasing size and complexity, to be used as examples (or starter projects) in SE courses.
 
-  * [**Level 1**](https://github.com/se-edu/addressbook-level1) [1 KLoC] : Non-OOP, No GUI (Command Line Interface)
-  * [**Level 2**](https://github.com/se-edu/addressbook-level2) [2 KLoC] : OOP, No GUI (Command Line Interface)
-  * [**Level 3**](https://github.com/se-edu/addressbook-level3) [3 KLoC] : Simple GUI with text input and output<br><br>
+  * [**Level 1**](../../../addressbook-level1) [1 KLoC] : Non-OOP, No GUI (Command Line Interface)
+  * [**Level 2**](../../../addressbook-level2) [2 KLoC] : OOP, No GUI (Command Line Interface)
+  * [**Level 3**](../../../addressbook-level3) [3 KLoC] : Simple GUI with text input and output<br><br>
     <img src="https://github.com/se-edu/addressbook-level3/raw/master/doc/images/Ui.png" >
     
-  * [**Level 4**](https://github.com/se-edu/addressbook-level4) [6 KLoC] : Better GUI and more features<br><br>
+  * [**Level 4**](../../../addressbook-level4) [6 KLoC] : Better GUI and more features<br><br>
     <img src="https://github.com/se-edu/addressbook-level4/raw/master/docs/images/Ui.png" >
     
   * **Levels 5, 6, ...** (Coming soon)


### PR DESCRIPTION
Fixes #5.

Links to "AddressBook" projects are absolute, while links to "RCS" and "Collate" projects are relative.

This makes the links in the same page inconsistent when visiting se-edu.github.io's GitHub Page, as links to "RCS" and "Collate" would direct visitors to their respective GitHub Pages, but links to "AddressBook" would direct them to their GitHub repositories.

Let's make the links behave consistently by using relative links. This way, the se-edu.github.io's GitHub Page version will point to other GitHub Pages, while the GitHub repository version will point to other GitHub repositories.