### PR TITLE
travis.yml: use jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk9
+    - jdk: openjdk11
 
 script: >-
     ./gradlew
@@ -13,10 +13,6 @@ deploy:
   on:
     branch: docs
 
-addons:
-  apt:
-    packages:
-      - oracle-java9-installer
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
the current jdk9 seems to break travis. 